### PR TITLE
feat(site): integrate landing bundle as Astro project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "secure-pride",
+  "private": true,
+  "workspaces": [
+    "site"
+  ],
+  "scripts": {
+    "build": "npm -w site run build",
+    "dev": "npm -w site run dev",
+    "preview": "npm -w site run preview"
+  }
+}

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  output: 'static',
+  site: 'https://securepride.org',
+});

--- a/site/package.json
+++ b/site/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "secure-pride-site",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "astro": "^4.16.0",
+    "marked": "^13.0.0"
+  }
+}

--- a/site/src/components/blog/BlogCard.astro
+++ b/site/src/components/blog/BlogCard.astro
@@ -1,0 +1,134 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import TagPill from './TagPill.astro';
+
+interface Props {
+  entry: CollectionEntry<'blog'>;
+}
+
+const { entry } = Astro.props;
+const { title, description, pubDate, image, imageAlt, tags } = entry.data;
+const href = `/blog/${entry.slug}`;
+
+const formattedDate = pubDate.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+});
+---
+
+<article class="blog-card">
+  <a href={href} class="blog-card__link" tabindex="-1" aria-hidden="true">
+    {image && (
+      <img
+        src={image}
+        alt={imageAlt ?? ''}
+        class="blog-card__image"
+        loading="lazy"
+        decoding="async"
+        width="640"
+        height="360"
+      />
+    )}
+  </a>
+
+  <div class="blog-card__body">
+    {tags && tags.length > 0 && (
+      <ul class="blog-card__tags" aria-label="Tags">
+        {tags.map((tag) => <li><TagPill tag={tag} /></li>)}
+      </ul>
+    )}
+
+    <h2 class="blog-card__title">
+      <a href={href}>{title}</a>
+    </h2>
+
+    <p class="blog-card__description">{description}</p>
+
+    <time datetime={pubDate.toISOString()} class="blog-card__date">{formattedDate}</time>
+  </div>
+</article>
+
+<style>
+  .blog-card {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 16px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.03);
+    transition: border-color 0.2s ease;
+  }
+
+  .blog-card:hover {
+    border-color: rgba(22, 224, 245, 0.3);
+  }
+
+  .blog-card__link {
+    display: block;
+    overflow: hidden;
+  }
+
+  .blog-card__image {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    display: block;
+    transition: transform 0.3s ease;
+  }
+
+  .blog-card:hover .blog-card__image {
+    transform: scale(1.02);
+  }
+
+  .blog-card__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1.25rem;
+    flex: 1;
+  }
+
+  .blog-card__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .blog-card__title {
+    font-size: 1.15rem;
+    font-weight: 700;
+    line-height: 1.3;
+    margin: 0;
+  }
+
+  .blog-card__title a {
+    color: #ffffff;
+    text-decoration: none;
+  }
+
+  .blog-card__title a:hover,
+  .blog-card__title a:focus-visible {
+    color: rgba(22, 224, 245, 0.95);
+    outline: 2px solid rgba(22, 224, 245, 0.5);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  .blog-card__description {
+    font-size: 0.92rem;
+    opacity: 0.75;
+    line-height: 1.55;
+    margin: 0;
+  }
+
+  .blog-card__date {
+    font-size: 0.8rem;
+    opacity: 0.5;
+    margin-top: auto;
+    padding-top: 0.5rem;
+  }
+</style>

--- a/site/src/components/blog/PostMeta.astro
+++ b/site/src/components/blog/PostMeta.astro
@@ -1,0 +1,69 @@
+---
+import TagPill from './TagPill.astro';
+
+interface Props {
+  pubDate: Date;
+  author?: string;
+  tags?: string[];
+}
+
+const { pubDate, author = 'Secure Pride', tags } = Astro.props;
+
+const formattedDate = pubDate.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+---
+
+<div class="post-meta">
+  <span class="post-meta__byline">
+    <span class="post-meta__author">{author}</span>
+    <span class="post-meta__sep" aria-hidden="true">·</span>
+    <time datetime={pubDate.toISOString()} class="post-meta__date">{formattedDate}</time>
+  </span>
+
+  {tags && tags.length > 0 && (
+    <ul class="post-meta__tags" aria-label="Tags">
+      {tags.map((tag) => (
+        <li><TagPill tag={tag} /></li>
+      ))}
+    </ul>
+  )}
+</div>
+
+<style>
+  .post-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+    font-size: 0.875rem;
+    opacity: 0.75;
+  }
+
+  .post-meta__byline {
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+  }
+
+  .post-meta__author {
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.9);
+  }
+
+  .post-meta__sep {
+    opacity: 0.5;
+  }
+
+  .post-meta__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+</style>

--- a/site/src/components/blog/TagPill.astro
+++ b/site/src/components/blog/TagPill.astro
@@ -1,0 +1,25 @@
+---
+interface Props {
+  tag: string;
+}
+
+const { tag } = Astro.props;
+---
+
+<span class="tag-pill">{tag}</span>
+
+<style>
+  .tag-pill {
+    display: inline-block;
+    padding: 0.2em 0.7em;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: lowercase;
+    background: rgba(22, 224, 245, 0.1);
+    color: rgba(22, 224, 245, 0.9);
+    border: 1px solid rgba(22, 224, 245, 0.25);
+    white-space: nowrap;
+  }
+</style>

--- a/site/src/components/blog/Triptych.astro
+++ b/site/src/components/blog/Triptych.astro
@@ -1,0 +1,67 @@
+---
+interface Panel {
+  src: string;
+  alt: string;
+  caption?: string;
+}
+
+interface Props {
+  panels: Panel[];
+  label?: string;
+}
+
+const { panels, label } = Astro.props;
+
+if (panels.length !== 3) {
+  throw new Error(`Triptych requires exactly 3 panels; received ${panels.length}.`);
+}
+---
+
+<figure class="triptych" aria-label={label ?? 'Three-panel image sequence'}>
+  {panels.map(({ src, alt, caption }) => (
+    <div class="triptych__panel">
+      <img src={src} alt={alt} loading="lazy" decoding="async" />
+      {caption && <figcaption>{caption}</figcaption>}
+    </div>
+  ))}
+</figure>
+
+<style>
+  .triptych {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.75rem;
+    margin: 2em 0;
+  }
+
+  .triptych__panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .triptych__panel img {
+    width: 100%;
+    aspect-ratio: 3 / 4;
+    object-fit: cover;
+    border-radius: 8px;
+    display: block;
+  }
+
+  .triptych__panel figcaption {
+    font-size: 0.8rem;
+    text-align: center;
+    opacity: 0.6;
+    line-height: 1.4;
+  }
+
+  @media (max-width: 640px) {
+    .triptych {
+      grid-template-columns: 1fr;
+    }
+
+    .triptych__panel img {
+      aspect-ratio: 4 / 3;
+    }
+  }
+</style>

--- a/site/src/components/landing/Deliverables.astro
+++ b/site/src/components/landing/Deliverables.astro
@@ -1,0 +1,27 @@
+---
+import { marked } from 'marked';
+
+const { copy } = Astro.props;
+
+function sliceBetween(md: string, start: string, end: string): string {
+  const s = md.indexOf(start);
+  if (s === -1) return '';
+  const e = md.indexOf(end, s + start.length);
+  return md.slice(s + start.length, e === -1 ? md.length : e).trim();
+}
+
+const deliverables = sliceBetween(copy, '## DELIVERABLES_BLOCK_START', '## DELIVERABLES_BLOCK_END');
+const deliverablesHtml = marked.parse(deliverables, { breaks: true }) as string;
+---
+
+<section class="section">
+  <div class="wrap">
+    <h2>What you receive</h2>
+    <div class="md__rendered" set:html={deliverablesHtml} />
+  </div>
+</section>
+
+<style>
+  .wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.25rem; }
+  .section { padding: 2.5rem 0; }
+</style>

--- a/site/src/components/landing/FAQ.astro
+++ b/site/src/components/landing/FAQ.astro
@@ -1,0 +1,79 @@
+---
+const { faq } = Astro.props;
+
+interface QAPair {
+  q: string;
+  a: string;
+}
+
+// Parse the custom Q: / A: format into structured pairs
+function parseQA(src: string): QAPair[] {
+  const pairs: QAPair[] = [];
+  let current: Partial<QAPair> | null = null;
+
+  for (const line of src.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('Q:')) {
+      if (current?.q && current?.a) pairs.push(current as QAPair);
+      current = { q: trimmed.slice(2).trim(), a: '' };
+    } else if (trimmed.startsWith('A:') && current) {
+      current.a = trimmed.slice(2).trim();
+    }
+  }
+  if (current?.q && current?.a) pairs.push(current as QAPair);
+  return pairs;
+}
+
+const pairs = parseQA(faq);
+---
+
+<section class="faq" aria-labelledby="faq-title">
+  <h3 id="faq-title">Frequently asked questions</h3>
+  <dl class="faq__list">
+    {pairs.map(({ q, a }) => (
+      <>
+        <dt class="faq__question">{q}</dt>
+        <dd class="faq__answer">{a}</dd>
+      </>
+    ))}
+  </dl>
+</section>
+
+<style>
+  .faq {
+    margin-top: 1.75rem;
+    padding: 1.25rem 1.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .faq h3 {
+    font-size: 1.05rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+  }
+
+  .faq__list {
+    display: grid;
+    gap: 0;
+  }
+
+  .faq__question {
+    font-weight: 600;
+    opacity: 0.95;
+    margin-top: 0.85rem;
+    font-size: 0.95rem;
+  }
+
+  .faq__question:first-of-type {
+    margin-top: 0;
+  }
+
+  .faq__answer {
+    margin: 0.2rem 0 0 0;
+    opacity: 0.75;
+    font-size: 0.9rem;
+    line-height: 1.6;
+  }
+</style>

--- a/site/src/components/landing/FinalCTA.astro
+++ b/site/src/components/landing/FinalCTA.astro
@@ -1,0 +1,28 @@
+---
+const { headline, subhead, primaryCtaHref, primaryCtaLabel, secondaryCtaHref, secondaryCtaLabel, note } = Astro.props;
+---
+
+<section class="finalcta" aria-labelledby="finalcta-title">
+  <div class="wrap">
+    <h2 id="finalcta-title">{headline}</h2>
+    <p class="lede">{subhead}</p>
+
+    <div class="ctas">
+      <a class="btn btn--primary" href={primaryCtaHref}>{primaryCtaLabel}</a>
+      <a class="btn btn--secondary" href={secondaryCtaHref}>{secondaryCtaLabel}</a>
+    </div>
+
+    <p class="note">{note}</p>
+  </div>
+</section>
+
+<style>
+  .finalcta { padding: 4rem 0; border-top: 1px solid rgba(255,255,255,0.10); }
+  .wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.25rem; }
+  .lede { max-width: 70ch; opacity: 0.9; }
+  .ctas { display: flex; gap: 0.75rem; margin-top: 1.25rem; flex-wrap: wrap; }
+  .note { margin-top: 1rem; opacity: 0.8; font-size: 0.95rem; }
+  .btn { display:inline-flex; align-items:center; justify-content:center; padding: 0.75rem 1rem; border-radius: 14px; text-decoration: none; font-weight: 600; }
+  .btn--primary { background: rgba(22,224,245,0.15); border: 1px solid rgba(22,224,245,0.35); }
+  .btn--secondary { background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.12); }
+</style>

--- a/site/src/components/landing/Hero.astro
+++ b/site/src/components/landing/Hero.astro
@@ -1,0 +1,61 @@
+---
+const {
+  headline,
+  subhead,
+  primaryCtaHref,
+  primaryCtaLabel,
+  secondaryCtaHref,
+  secondaryCtaLabel,
+  imageSrc,
+  imageAlt,
+} = Astro.props;
+---
+
+<section class="hero" aria-labelledby="hero-title">
+  <div class="hero__inner">
+    <div class="hero__copy">
+      <h1 id="hero-title">{headline}</h1>
+      <p class="hero__sub">{subhead}</p>
+
+      <div class="hero__ctas">
+        <a class="btn btn--primary" href={primaryCtaHref}>{primaryCtaLabel}</a>
+        <a class="btn btn--secondary" href={secondaryCtaHref}>{secondaryCtaLabel}</a>
+      </div>
+
+      <ul class="hero__pills" aria-label="Key attributes">
+        <li>Local-first</li>
+        <li>No vendor lock-in</li>
+        <li>Actionable remediation</li>
+        <li>Community-threat aware</li>
+      </ul>
+    </div>
+
+    <div class="hero__media">
+      <img src={imageSrc} alt={imageAlt} loading="eager" decoding="async" />
+    </div>
+  </div>
+</section>
+
+<style>
+  .hero { padding: 4.5rem 1.25rem; }
+  .hero__inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 1.1fr 0.9fr;
+    gap: 2.5rem;
+    align-items: center;
+  }
+  h1 { font-size: clamp(2rem, 3vw, 3rem); line-height: 1.05; margin: 0; }
+  .hero__sub { max-width: 55ch; opacity: 0.9; font-size: 1.05rem; margin-top: 0.85rem; }
+  .hero__ctas { display: flex; gap: 0.75rem; margin-top: 1.25rem; flex-wrap: wrap; }
+  .hero__pills { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 1.25rem; padding: 0; list-style: none; }
+  .hero__pills li { border: 1px solid rgba(255,255,255,0.15); padding: 0.35rem 0.6rem; border-radius: 999px; font-size: 0.9rem; }
+  .hero__media img { width: 100%; height: auto; border-radius: 18px; }
+  @media (max-width: 900px) {
+    .hero__inner { grid-template-columns: 1fr; }
+  }
+  .btn { display:inline-flex; align-items:center; justify-content:center; padding: 0.75rem 1rem; border-radius: 14px; text-decoration: none; font-weight: 600; }
+  .btn--primary { background: rgba(22,224,245,0.15); border: 1px solid rgba(22,224,245,0.35); }
+  .btn--secondary { background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.12); }
+</style>

--- a/site/src/components/landing/Proof.astro
+++ b/site/src/components/landing/Proof.astro
@@ -1,0 +1,27 @@
+---
+import { marked } from 'marked';
+
+const { copy } = Astro.props;
+
+function sliceBetween(md: string, start: string, end: string): string {
+  const s = md.indexOf(start);
+  if (s === -1) return '';
+  const e = md.indexOf(end, s + start.length);
+  return md.slice(s + start.length, e === -1 ? md.length : e).trim();
+}
+
+const proof = sliceBetween(copy, '## PROOF_BLOCK_START', '## PROOF_BLOCK_END');
+const proofHtml = marked.parse(proof, { breaks: true }) as string;
+---
+
+<section class="section">
+  <div class="wrap">
+    <h2>Security is stewardship, not software theater.</h2>
+    <div class="md__rendered" set:html={proofHtml} />
+  </div>
+</section>
+
+<style>
+  .wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.25rem; }
+  .section { padding: 2.5rem 0; }
+</style>

--- a/site/src/components/landing/ToolkitLayers.astro
+++ b/site/src/components/landing/ToolkitLayers.astro
@@ -1,0 +1,31 @@
+---
+import { marked } from 'marked';
+
+const { copy } = Astro.props;
+
+function sliceBetween(md: string, start: string, end: string): string {
+  const s = md.indexOf(start);
+  if (s === -1) return '';
+  const e = md.indexOf(end, s + start.length);
+  return md.slice(s + start.length, e === -1 ? md.length : e).trim();
+}
+
+const layers = sliceBetween(copy, '## TOOLKIT_BLOCK_START', '## TOOLKIT_BLOCK_END');
+const layersHtml = marked.parse(layers, { breaks: true }) as string;
+---
+
+<section class="section">
+  <div class="wrap">
+    <h2>The Secure Pride Audit Toolkit</h2>
+    <p class="lede">
+      A structured audit system that identifies exposure and delivers fixes—without surveillance.
+    </p>
+    <div class="md__rendered" set:html={layersHtml} />
+  </div>
+</section>
+
+<style>
+  .wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.25rem; }
+  .section { padding: 2.5rem 0; }
+  .lede { max-width: 70ch; opacity: 0.9; margin-bottom: 1.25rem; }
+</style>

--- a/site/src/components/landing/Trust.astro
+++ b/site/src/components/landing/Trust.astro
@@ -1,0 +1,21 @@
+---
+import { marked } from 'marked';
+import FAQ from './FAQ.astro';
+
+const { copy, faq } = Astro.props;
+
+const trustHtml = marked.parse(copy, { breaks: true }) as string;
+---
+
+<section class="section">
+  <div class="wrap">
+    <h2>Privacy-respecting by design</h2>
+    <div class="md__rendered" set:html={trustHtml} />
+    <FAQ faq={faq} />
+  </div>
+</section>
+
+<style>
+  .wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.25rem; }
+  .section { padding: 2.5rem 0; }
+</style>

--- a/site/src/components/shared/SiteCTA.astro
+++ b/site/src/components/shared/SiteCTA.astro
@@ -1,0 +1,74 @@
+---
+/**
+ * Minimal site-wide CTA component.
+ * Variants: "inline" (within page flow) | "footer" (end-cap)
+ */
+const {
+  variant = "inline",
+  headline,
+  subhead,
+  primaryHref,
+  primaryLabel,
+  secondaryHref,
+  secondaryLabel,
+} = Astro.props;
+---
+
+<section class={`sitecta sitecta--${variant}`} aria-label="Call to action">
+  <div class="sitecta__inner">
+    <div class="sitecta__copy">
+      <h2 class="sitecta__title">{headline}</h2>
+      {subhead && <p class="sitecta__sub">{subhead}</p>}
+    </div>
+
+    <div class="sitecta__actions">
+      <a class="btn btn--primary" href={primaryHref}>{primaryLabel}</a>
+      {secondaryHref && secondaryLabel && (
+        <a class="btn btn--secondary" href={secondaryHref}>{secondaryLabel}</a>
+      )}
+    </div>
+  </div>
+</section>
+
+<style>
+  .sitecta {
+    padding: 2.25rem 1.25rem;
+  }
+  .sitecta--footer {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+    border-top: 1px solid rgba(255,255,255,0.10);
+  }
+  .sitecta__inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 1rem;
+    align-items: center;
+    border: 1px solid rgba(255,255,255,0.12);
+    border-radius: 18px;
+    background: rgba(255,255,255,0.03);
+    padding: 1.25rem;
+  }
+  .sitecta__title { margin: 0; font-size: 1.35rem; }
+  .sitecta__sub { margin: 0.35rem 0 0; opacity: 0.9; max-width: 70ch; }
+  .sitecta__actions { display: inline-flex; gap: 0.75rem; justify-content: flex-end; flex-wrap: wrap; }
+  .btn {
+    display:inline-flex;
+    align-items:center;
+    justify-content:center;
+    padding: 0.75rem 1rem;
+    border-radius: 14px;
+    text-decoration: none;
+    font-weight: 650;
+    line-height: 1;
+    white-space: nowrap;
+  }
+  .btn--primary { background: rgba(22,224,245,0.15); border: 1px solid rgba(22,224,245,0.35); }
+  .btn--secondary { background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.12); }
+  @media (max-width: 900px) {
+    .sitecta__inner { grid-template-columns: 1fr; }
+    .sitecta__actions { justify-content: flex-start; }
+  }
+</style>

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,0 +1,17 @@
+import { defineCollection, z } from 'astro:content';
+
+const blog = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    pubDate: z.coerce.date(),
+    image: z.string().optional(),
+    imageAlt: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+    author: z.string().optional(),
+  }),
+});
+
+// Landing files are consumed via `?raw` imports — no schema needed.
+export const collections = { blog };

--- a/site/src/content/blog/the-lock-icon-is-not-security.mdx
+++ b/site/src/content/blog/the-lock-icon-is-not-security.mdx
@@ -1,0 +1,11 @@
+---
+title: "The lock icon is not security"
+description: "Why the padlock in your browser bar is the beginning of the question, not the answer."
+pubDate: 2026-03-22
+image: /hero-lock-icon.jpg
+imageAlt: "Brass heart-shaped padlock against dark background"
+tags: ["security", "education", "basics"]
+author: "Secure Pride"
+---
+
+{/* Drop your content here. The frontmatter above wires the hero image, tags, and OG metadata automatically. */}

--- a/site/src/content/blog/we-all-float-on.mdx
+++ b/site/src/content/blog/we-all-float-on.mdx
@@ -1,0 +1,25 @@
+---
+title: "We all float on"
+description: "On resilience, redundancy, and what it means to build infrastructure that survives contact with the world."
+pubDate: 2026-03-22
+image: /triptych/triptych-instrument.png
+imageAlt: "Three-panel photograph sequence"
+tags: ["resilience", "community", "infrastructure"]
+author: "Secure Pride"
+---
+
+import Triptych from '../../components/blog/Triptych.astro';
+
+{/* Drop your content here.
+    To render the three-panel image block, use the Triptych component like this:
+
+<Triptych
+  panels={[
+    { src: "/triptych/triptych-mind.png", alt: "Description of first panel", caption: "Optional caption" },
+    { src: "/triptych/triptych-instrument.png", alt: "Description of second panel", caption: "Optional caption" },
+    { src: "/triptych/YOUR-THIRD-IMAGE.png", alt: "Description of third panel", caption: "Optional caption" },
+  ]}
+  label="Three-panel triptych"
+/>
+
+Replace YOUR-THIRD-IMAGE with the actual filename of the third triptych image. */}

--- a/site/src/content/landing/audit-toolkit.copy.md
+++ b/site/src/content/landing/audit-toolkit.copy.md
@@ -1,0 +1,76 @@
+## PROOF_BLOCK_START
+
+Security is stewardship, not software theater.
+
+- Targeting is asymmetric: small orgs get hit because they’re exposed, not because they’re “important.”
+- Most compromises are boring: misconfigurations, weak email authentication, bad TLS modes, leaked secrets.
+- Resilience is buildable: audit → fix → document → repeat.
+
+Misconfigurations we routinely see:
+- Flexible SSL + redirect loops
+- Missing/weak DMARC enforcement
+- Overexposed subdomains and admin surfaces
+- Missing security headers / overly-permissive CSP
+- Secrets committed to repos or printed in CI logs
+
+What changes after an audit:
+- Smaller public footprint
+- Verifiable email authenticity
+- Fewer easy phishing vectors
+- Clear remediation backlog
+- Repeatable audit cadence
+
+## PROOF_BLOCK_END
+
+
+## TOOLKIT_BLOCK_START
+
+Layer 1 — Surface Audit
+What the public internet can see.
+- DNS posture (A/AAAA/CNAME/MX)
+- TLS and certificate checks
+- Redirect rules + loop detection
+- Email authentication review (SPF/DKIM/DMARC)
+- Subdomain exposure scan
+Output: Prioritized exposure report.
+
+Layer 2 — Configuration Integrity
+What’s misconfigured (and how to fix it).
+- Cloudflare settings review
+- HSTS + security headers
+- CSP baseline and gaps
+- CI/CD + environment exposure patterns
+Output: Pass/fail checklist + step-by-step remediation.
+
+Layer 3 — Operational Hardening
+The human layer attackers exploit.
+- MFA enforcement guidance
+- Admin surface reduction
+- Registrar access review
+- Secret storage practices
+- Backup verification + incident readiness
+Output: Resilience roadmap (impact vs effort).
+
+## TOOLKIT_BLOCK_END
+
+
+## DELIVERABLES_BLOCK_START
+
+You receive:
+- Findings report with severity tiers
+- Remediation checklist with clear owners
+- Configuration templates: DNS / TLS / Email auth / CSP
+- Roadmap ranked by impact → effort
+- Suggested cadence: quarterly / biannual
+
+What this is not:
+- Not surveillance
+- Not tracking scripts
+- Not a SaaS dashboard that holds your data
+
+Deployment options:
+- Self-Guided Audit: run locally, generate a report, apply fixes on your timeline.
+- Guided Review: walk through findings with Secure Pride.
+- Hardened Implementation: optional help implementing corrections.
+
+## DELIVERABLES_BLOCK_END

--- a/site/src/content/landing/audit-toolkit.faq.md
+++ b/site/src/content/landing/audit-toolkit.faq.md
@@ -1,0 +1,14 @@
+Q: Do you need admin access?
+A: Self-guided: no. Guided: only if you choose implementation support.
+
+Q: Will this break my site or email?
+A: The toolkit recommends changes; you approve and apply. We prioritize reversible steps.
+
+Q: What platforms does this support?
+A: Cloudflare-first, but adaptable to any DNS/hosting provider.
+
+Q: Is this a monitoring product?
+A: No. It’s an audit + remediation system. No tracking scripts, no centralized surveillance.
+
+Q: What if we’re under active attack?
+A: We can prioritize urgent triage and rapid hardening.

--- a/site/src/content/landing/audit-toolkit.seo.md
+++ b/site/src/content/landing/audit-toolkit.seo.md
@@ -1,0 +1,14 @@
+title: Secure Pride Audit Toolkit
+description: Privacy-respecting security audits for community orgs—clear findings, practical fixes, zero surveillance.
+og_title: Secure Pride Audit Toolkit
+og_description: Harden what you care about—actionable audit findings and remediation without surveillance or vendor lock-in.
+og_image: /og/securepride-audit-toolkit.png
+
+hero_headline: Harden what you care about.
+hero_subhead: Security audits for community orgs and small teams—clear findings, practical fixes, zero surveillance.
+hero_image: /og/securepride-audit-toolkit.png
+hero_image_alt: Heart-shaped brass padlock with subtle internal warmth in darkness
+
+finalcta_headline: Protect the people behind the infrastructure.
+finalcta_subhead: Start with an audit. Fix what matters. Build repeatable resilience.
+finalcta_note: Already under active attack? We’ll prioritize urgent triage.

--- a/site/src/content/landing/audit-toolkit.trust.md
+++ b/site/src/content/landing/audit-toolkit.trust.md
@@ -1,0 +1,6 @@
+- Local-first workflow: run audits in your environment.
+- Data minimization: collect only what’s required to generate findings.
+- No telemetry by default.
+- Transparent outputs: you get the report; you keep the report.
+- Threat-informed: modeled for harassment, doxxing, and targeted compromise realities.
+- Documentation-first: every check is explained; fixes are reproducible.

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -1,0 +1,262 @@
+---
+interface Props {
+  title: string;
+  description: string;
+}
+
+const { title, description } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content={description} />
+    <title>{title}</title>
+    <slot name="head" />
+  </head>
+  <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+
+    <header class="site-header" role="banner">
+      <div class="site-header__inner">
+        <a href="/" class="site-logo" aria-label="Secure Pride — home">
+          Secure Pride
+        </a>
+        <nav aria-label="Main navigation">
+          <ul>
+            <li><a href="/audit-toolkit">Audit Toolkit</a></li>
+            <li><a href="/get-started">Get Started</a></li>
+            <li><a href="/blog">Blog</a></li>
+            <li><a href="/contact" class="nav-cta">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <div id="main-content" tabindex="-1">
+      <slot />
+    </div>
+
+    <footer class="site-footer" role="contentinfo">
+      <div class="site-footer__inner">
+        <p class="site-footer__copy">
+          &copy; {new Date().getFullYear()} Secure Pride &middot;
+          <a href="https://securepride.org">securepride.org</a>
+        </p>
+        <p class="site-footer__policy">No telemetry. No tracking. No exceptions.</p>
+      </div>
+    </footer>
+  </body>
+</html>
+
+<style is:global>
+  /* ── Reset ─────────────────────────────────────────────────────────────── */
+  *, *::before, *::after { box-sizing: border-box; }
+  * { margin: 0; }
+  img, video { max-width: 100%; display: block; }
+
+  /* ── Base ───────────────────────────────────────────────────────────────── */
+  :root {
+    --color-bg:          #0d0d0f;
+    --color-text:        rgba(255, 255, 255, 0.92);
+    --color-accent:      rgba(22, 224, 245, 0.95);
+    --color-accent-dim:  rgba(22, 224, 245, 0.35);
+    --color-border:      rgba(255, 255, 255, 0.12);
+    --font-sans:         system-ui, -apple-system, "Segoe UI", sans-serif;
+    --max-w:             1100px;
+  }
+
+  html {
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    font-family: var(--font-sans);
+    font-size: 1rem;
+    line-height: 1.75;
+    -webkit-text-size-adjust: 100%;
+  }
+
+  body {
+    min-height: 100dvh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  #main-content {
+    flex: 1;
+    outline: none; /* skip-link target: suppress visible outline on programmatic focus */
+  }
+
+  /* ── Accessible focus ─────────────────────────────────────────────────── */
+  :focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 3px;
+    border-radius: 4px;
+  }
+
+  /* ── Skip link ────────────────────────────────────────────────────────── */
+  .skip-link {
+    position: absolute;
+    top: -100%;
+    left: 1rem;
+    z-index: 9999;
+    padding: 0.6rem 1rem;
+    background: var(--color-bg);
+    color: var(--color-accent);
+    border: 1px solid var(--color-accent-dim);
+    border-radius: 6px;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.95rem;
+    transition: top 0.1s;
+  }
+
+  .skip-link:focus {
+    top: 1rem;
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+  }
+
+  /* ── Site header ──────────────────────────────────────────────────────── */
+  .site-header {
+    border-bottom: 1px solid var(--color-border);
+    padding: 0 1.25rem;
+  }
+
+  .site-header__inner {
+    max-width: var(--max-w);
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+    height: 3.5rem;
+  }
+
+  .site-logo {
+    font-weight: 700;
+    font-size: 1rem;
+    letter-spacing: -0.01em;
+    color: #fff;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .site-header nav ul {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    flex-wrap: wrap;
+  }
+
+  .site-header nav a {
+    padding: 0.4rem 0.65rem;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    text-decoration: none;
+    color: rgba(255, 255, 255, 0.8);
+    transition: color 0.15s, background 0.15s;
+  }
+
+  .site-header nav a:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .site-header nav .nav-cta {
+    background: rgba(22, 224, 245, 0.1);
+    border: 1px solid rgba(22, 224, 245, 0.25);
+    color: rgba(22, 224, 245, 0.9);
+  }
+
+  .site-header nav .nav-cta:hover {
+    background: rgba(22, 224, 245, 0.18);
+    color: rgba(22, 224, 245, 1);
+  }
+
+  /* ── Site footer ──────────────────────────────────────────────────────── */
+  .site-footer {
+    margin-top: auto;
+    border-top: 1px solid var(--color-border);
+    padding: 2rem 1.25rem;
+    font-size: 0.875rem;
+  }
+
+  .site-footer__inner {
+    max-width: var(--max-w);
+    margin: 0 auto;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 2rem;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .site-footer__copy {
+    opacity: 0.7;
+  }
+
+  .site-footer__copy a {
+    color: var(--color-accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .site-footer__policy {
+    opacity: 0.45;
+    font-size: 0.8rem;
+  }
+
+  /* ── Shared button tokens (used across landing components) ─────────────── */
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1rem;
+    border-radius: 14px;
+    text-decoration: none;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+    transition: background 0.15s, border-color 0.15s;
+  }
+
+  .btn--primary {
+    background: rgba(22, 224, 245, 0.15);
+    border: 1px solid rgba(22, 224, 245, 0.35);
+    color: rgba(22, 224, 245, 0.95);
+  }
+
+  .btn--primary:hover {
+    background: rgba(22, 224, 245, 0.22);
+    border-color: rgba(22, 224, 245, 0.5);
+  }
+
+  .btn--secondary {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: rgba(255, 255, 255, 0.85);
+  }
+
+  .btn--secondary:hover {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.2);
+  }
+
+  /* ── Rendered markdown sections (landing pages) ─────────────────────── */
+  .md__rendered p       { margin: 0 0 0.85em; opacity: 0.92; }
+  .md__rendered p:last-child { margin-bottom: 0; }
+  .md__rendered ul,
+  .md__rendered ol      { padding-left: 1.4rem; margin: 0 0 0.85em; }
+  .md__rendered li      { margin-bottom: 0.35em; }
+  .md__rendered strong  { font-weight: 700; color: #fff; }
+
+  /* ── Responsive header ────────────────────────────────────────────────── */
+  @media (max-width: 640px) {
+    .site-header nav a { font-size: 0.82rem; padding: 0.35rem 0.5rem; }
+  }
+</style>

--- a/site/src/layouts/BlogPost.astro
+++ b/site/src/layouts/BlogPost.astro
@@ -1,0 +1,79 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import BaseLayout from './BaseLayout.astro';
+import PostMeta from '../components/blog/PostMeta.astro';
+import SiteCTA from '../components/shared/SiteCTA.astro';
+import '../styles/editorial.css';
+
+interface Props {
+  entry: CollectionEntry<'blog'>;
+}
+
+const { entry } = Astro.props;
+const { title, description, pubDate, image, imageAlt, tags, author } = entry.data;
+---
+
+<BaseLayout title={`${title} | Secure Pride`} description={description}>
+  <Fragment slot="head">
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="article" />
+    {image && <meta property="og:image" content={image} />}
+    <meta name="twitter:card" content={image ? 'summary_large_image' : 'summary'} />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    {image && <meta name="twitter:image" content={image} />}
+  </Fragment>
+
+  <main class="blog-main">
+    <article class="wrap">
+      {image && (
+        <img
+          src={image}
+          alt={imageAlt ?? ''}
+          class="post-hero-image"
+          loading="eager"
+          decoding="async"
+        />
+      )}
+
+      <header class="post-header">
+        <h1>{title}</h1>
+        <p class="post-description">{description}</p>
+        <PostMeta pubDate={pubDate} author={author} tags={tags} />
+      </header>
+
+      <div class="prose">
+        <slot />
+      </div>
+    </article>
+
+    <div class="wrap cta-wrap">
+      <SiteCTA
+        variant="footer"
+        headline="Protect what you've built."
+        subhead="Run the audit toolkit or request a guided review."
+        primaryHref="/get-started"
+        primaryLabel="Get started"
+        secondaryHref="/audit-toolkit"
+        secondaryLabel="Audit toolkit"
+      />
+    </div>
+  </main>
+</BaseLayout>
+
+<style>
+  .blog-main {
+    padding: 3rem 0 5rem;
+  }
+
+  .wrap {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 1.25rem;
+  }
+
+  .cta-wrap {
+    margin-top: 4rem;
+  }
+</style>

--- a/site/src/pages/audit-toolkit.astro
+++ b/site/src/pages/audit-toolkit.astro
@@ -1,0 +1,94 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+import Hero from '../components/landing/Hero.astro';
+import Proof from '../components/landing/Proof.astro';
+import ToolkitLayers from '../components/landing/ToolkitLayers.astro';
+import Deliverables from '../components/landing/Deliverables.astro';
+import Trust from '../components/landing/Trust.astro';
+import FinalCTA from '../components/landing/FinalCTA.astro';
+import SiteCTA from '../components/shared/SiteCTA.astro';
+
+import copy from '../content/landing/audit-toolkit.copy.md?raw';
+import seo from '../content/landing/audit-toolkit.seo.md?raw';
+import trustCopy from '../content/landing/audit-toolkit.trust.md?raw';
+import faq from '../content/landing/audit-toolkit.faq.md?raw';
+
+function parseKeyValue(md: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  md.split('\n').forEach((line) => {
+    const m = line.match(/^([A-Za-z0-9_-]+):\s*(.+)$/);
+    if (m) out[m[1]] = m[2].trim();
+  });
+  return out;
+}
+
+const meta = parseKeyValue(seo);
+const canonicalUrl = new URL('/audit-toolkit', Astro.site).toString();
+---
+
+<BaseLayout
+  title={meta.title ?? 'Secure Pride Audit Toolkit'}
+  description={meta.description ?? ''}
+>
+  <Fragment slot="head">
+    <link rel="canonical" href={canonicalUrl} />
+
+    <meta property="og:title"       content={meta.og_title ?? meta.title ?? 'Secure Pride Audit Toolkit'} />
+    <meta property="og:description" content={meta.og_description ?? meta.description ?? ''} />
+    <meta property="og:type"        content="website" />
+    <meta property="og:image"       content={meta.og_image ?? '/og/securepride-audit-toolkit.png'} />
+
+    <meta name="twitter:card"        content="summary_large_image" />
+    <meta name="twitter:title"       content={meta.twitter_title ?? meta.title ?? 'Secure Pride Audit Toolkit'} />
+    <meta name="twitter:description" content={meta.twitter_description ?? meta.description ?? ''} />
+    <meta name="twitter:image"       content={meta.og_image ?? '/og/securepride-audit-toolkit.png'} />
+  </Fragment>
+
+  <main class="landing" aria-label="Audit Toolkit landing page">
+    <Hero
+      headline={meta.hero_headline ?? 'Harden what you care about.'}
+      subhead={meta.hero_subhead ?? 'Security audits for community orgs and small teams—clear findings, practical fixes, zero surveillance.'}
+      primaryCtaHref="/get-started"
+      primaryCtaLabel="Run the Self-Guided Audit"
+      secondaryCtaHref="/contact"
+      secondaryCtaLabel="Request a Guided Review"
+      imageSrc={meta.hero_image ?? '/og/securepride-audit-toolkit.png'}
+      imageAlt={meta.hero_image_alt ?? 'Heart-shaped brass padlock with subtle internal warmth in darkness'}
+    />
+
+    <Proof copy={copy} />
+    <ToolkitLayers copy={copy} />
+    <Deliverables copy={copy} />
+    <Trust copy={trustCopy} faq={faq} />
+
+    <SiteCTA
+      variant="inline"
+      headline="Ready to run your first audit?"
+      subhead="Start self-guided in minutes, or request a guided review."
+      primaryHref="/get-started"
+      primaryLabel="Get started"
+      secondaryHref="/contact"
+      secondaryLabel="Talk to Secure Pride"
+    />
+
+    <FinalCTA
+      headline={meta.finalcta_headline ?? 'Protect the people behind the infrastructure.'}
+      subhead={meta.finalcta_subhead ?? 'Start with an audit. Fix what matters. Build repeatable resilience.'}
+      primaryCtaHref="/get-started"
+      primaryCtaLabel="Run the Self-Guided Audit"
+      secondaryCtaHref="/contact"
+      secondaryCtaLabel="Request a Guided Review"
+      note={meta.finalcta_note ?? "Already under active attack? We'll prioritize urgent triage."}
+    />
+  </main>
+</BaseLayout>
+
+<style>
+  .landing {
+    display: flex;
+    flex-direction: column;
+    gap: 4rem;
+    padding: 0;
+  }
+</style>

--- a/site/src/pages/blog/[slug].astro
+++ b/site/src/pages/blog/[slug].astro
@@ -1,0 +1,19 @@
+---
+import { getCollection } from 'astro:content';
+import BlogPost from '../../layouts/BlogPost.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map((entry) => ({
+    params: { slug: entry.slug },
+    props: { entry },
+  }));
+}
+
+const { entry } = Astro.props;
+const { Content } = await entry.render();
+---
+
+<BlogPost entry={entry}>
+  <Content />
+</BlogPost>

--- a/site/src/pages/blog/index.astro
+++ b/site/src/pages/blog/index.astro
@@ -1,0 +1,61 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import BlogCard from '../../components/blog/BlogCard.astro';
+
+const posts = (await getCollection('blog')).sort(
+  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+);
+---
+
+<BaseLayout
+  title="Blog | Secure Pride"
+  description="Security education, community resilience, and practical hardening guides from Secure Pride."
+>
+  <main class="blog-index">
+    <header class="wrap header">
+      <h1>Blog</h1>
+      <p class="lede">
+        Security education, community resilience, and practical hardening guides.
+      </p>
+    </header>
+
+    {posts.length === 0 ? (
+      <div class="wrap">
+        <p>No posts published yet. Check back soon.</p>
+      </div>
+    ) : (
+      <section class="wrap grid" aria-label="Blog posts">
+        {posts.map((entry) => <BlogCard entry={entry} />)}
+      </section>
+    )}
+  </main>
+</BaseLayout>
+
+<style>
+  .blog-index {
+    padding: 3.25rem 0 5rem;
+  }
+
+  .wrap {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 1.25rem;
+  }
+
+  .header {
+    margin-bottom: 2.5rem;
+  }
+
+  .lede {
+    max-width: 60ch;
+    opacity: 0.8;
+    line-height: 1.6;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 1.5rem;
+  }
+</style>

--- a/site/src/pages/contact.astro
+++ b/site/src/pages/contact.astro
@@ -1,0 +1,73 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import SiteCTA from "../components/shared/SiteCTA.astro";
+---
+
+<BaseLayout title="Contact | Secure Pride" description="Request a guided review or reach Secure Pride for audit support.">
+  <main class="page">
+    <header class="wrap header">
+      <h1>Contact</h1>
+      <p class="lede">
+        Tell us what you’re protecting and what constraints you’re working under. We’ll respond with next steps.
+      </p>
+    </header>
+
+    <section class="wrap grid" aria-label="Contact options">
+      <article class="card">
+        <h2>Request a guided review</h2>
+        <p>
+          Use your existing form system (or add one) and collect only what you need.
+        </p>
+        <ul>
+          <li>Primary domain</li>
+          <li>DNS provider + hosting stack</li>
+          <li>Email provider</li>
+          <li>Time sensitivity (normal / urgent)</li>
+        </ul>
+        <p class="hint">
+          Placeholder: wire this to your existing securepride.org contact form route or embed your form component here.
+        </p>
+      </article>
+
+      <article class="card">
+        <h2>Security contact</h2>
+        <p>
+          For responsible disclosure, use the security contact channel.
+        </p>
+        <p class="hint">
+          Placeholder: link to your <code>security.txt</code> and disclosure policy once published.
+        </p>
+      </article>
+    </section>
+
+    <section class="wrap">
+      <h2>What to expect</h2>
+      <ol>
+        <li>We confirm scope and urgency.</li>
+        <li>We run a surface audit and share prioritized findings.</li>
+        <li>We align on remediation ownership and cadence.</li>
+      </ol>
+    </section>
+
+    <SiteCTA
+      variant="footer"
+      headline="Prefer to start solo?"
+      subhead="Run the self-guided path first; bring the report if you want a second set of eyes."
+      primaryHref="/get-started"
+      primaryLabel="Get started"
+      secondaryHref="/audit-toolkit"
+      secondaryLabel="Toolkit overview"
+    />
+  </main>
+</BaseLayout>
+
+<style>
+  .page { padding: 3.25rem 0 4rem; }
+  .wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.25rem; }
+  .header { margin-bottom: 1.5rem; }
+  .lede { max-width: 70ch; opacity: 0.9; }
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; }
+  .card { border: 1px solid rgba(255,255,255,0.12); border-radius: 18px; padding: 1.25rem; background: rgba(255,255,255,0.03); }
+  .hint { opacity: 0.85; font-size: 0.95rem; }
+  @media (max-width: 900px) { .grid { grid-template-columns: 1fr; } }
+</style>

--- a/site/src/pages/get-started.astro
+++ b/site/src/pages/get-started.astro
@@ -1,0 +1,82 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import SiteCTA from "../components/shared/SiteCTA.astro";
+---
+
+<BaseLayout title="Get started | Secure Pride" description="Run the Secure Pride Audit Toolkit self-guided, or prepare for a guided review.">
+  <main class="page">
+    <header class="wrap header">
+      <h1>Get started</h1>
+      <p class="lede">
+        Choose the path that matches your capacity today. The goal is the same: reduce exposure, document fixes, and establish a repeatable cadence.
+      </p>
+    </header>
+
+    <section class="wrap grid" aria-label="Get started options">
+      <article class="card">
+        <h2>Self-guided audit</h2>
+        <p>
+          Run the toolkit locally, generate a report, and apply fixes on your timeline.
+        </p>
+        <ol>
+          <li>Collect your domain + DNS provider details.</li>
+          <li>Run the audit checks (CLI or checklist).</li>
+          <li>Apply the highest-impact remediations first.</li>
+          <li>Re-run the audit to verify improvements.</li>
+        </ol>
+        <p class="hint">
+          Next: replace this placeholder with the actual CLI instructions and a “Download / Run” button once the repo packaging is ready.
+        </p>
+      </article>
+
+      <article class="card">
+        <h2>Prepare for a guided review</h2>
+        <p>
+          If you’d rather not do this alone, we’ll walk through findings and help you prioritize fixes.
+        </p>
+        <ul>
+          <li>Domain + DNS provider (Cloudflare, etc.)</li>
+          <li>Email provider (Google Workspace, Proton, iCloud, etc.)</li>
+          <li>Hosting stack (Cloudflare Pages, GitHub Pages, etc.)</li>
+          <li>Any known incidents or concerns</li>
+        </ul>
+        <p class="hint">
+          Head to <a href="/contact">Contact</a> to request a review.
+        </p>
+      </article>
+    </section>
+
+    <section class="wrap">
+      <h2>What you’ll get</h2>
+      <ul class="bullets">
+        <li>Findings report with severity tiers</li>
+        <li>Remediation checklist with clear steps</li>
+        <li>Configuration templates (DNS, TLS, email auth, CSP)</li>
+        <li>Roadmap ranked by impact → effort</li>
+      </ul>
+    </section>
+
+    <SiteCTA
+      variant="footer"
+      headline="Start the audit."
+      subhead="Self-guided or guided—either way, you’ll leave with a concrete hardening plan."
+      primaryHref="/audit-toolkit"
+      primaryLabel="What’s included"
+      secondaryHref="/contact"
+      secondaryLabel="Request a guided review"
+    />
+  </main>
+</BaseLayout>
+
+<style>
+  .page { padding: 3.25rem 0 4rem; }
+  .wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.25rem; }
+  .header { margin-bottom: 1.5rem; }
+  .lede { max-width: 70ch; opacity: 0.9; }
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; }
+  .card { border: 1px solid rgba(255,255,255,0.12); border-radius: 18px; padding: 1.25rem; background: rgba(255,255,255,0.03); }
+  .hint { opacity: 0.85; font-size: 0.95rem; }
+  .bullets { display: grid; gap: 0.5rem; }
+  a { text-decoration: underline; }
+  @media (max-width: 900px) { .grid { grid-template-columns: 1fr; } }
+</style>

--- a/site/src/styles/editorial.css
+++ b/site/src/styles/editorial.css
@@ -1,0 +1,210 @@
+/* editorial.css — prose styles for blog posts
+   Import this in src/layouts/BlogPost.astro only.
+   All selectors are scoped under .prose to avoid leaking into the landing pages. */
+
+/* ─── Prose container ─────────────────────────────────────────────────────── */
+
+.prose {
+  max-width: 72ch;
+  margin: 0 auto;
+  padding: 0 1.25rem;
+  font-size: 1.0625rem;
+  line-height: 1.75;
+  color: rgba(255, 255, 255, 0.92);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+/* ─── Headings ────────────────────────────────────────────────────────────── */
+
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4 {
+  line-height: 1.25;
+  font-weight: 700;
+  color: #ffffff;
+  margin-top: 2.25em;
+  margin-bottom: 0.6em;
+}
+
+.prose h1 { font-size: 2rem; margin-top: 0; }
+.prose h2 { font-size: 1.5rem; }
+.prose h3 { font-size: 1.2rem; }
+.prose h4 { font-size: 1rem; letter-spacing: 0.03em; text-transform: uppercase; opacity: 0.8; }
+
+/* ─── Body text ───────────────────────────────────────────────────────────── */
+
+.prose p {
+  margin: 0 0 1.4em;
+}
+
+.prose strong {
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.prose em {
+  font-style: italic;
+}
+
+/* ─── Links ───────────────────────────────────────────────────────────────── */
+
+.prose a {
+  color: rgba(22, 224, 245, 0.95);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  transition: color 0.15s ease;
+}
+
+.prose a:hover,
+.prose a:focus-visible {
+  color: #ffffff;
+  outline: 2px solid rgba(22, 224, 245, 0.6);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* ─── Lists ───────────────────────────────────────────────────────────────── */
+
+.prose ul,
+.prose ol {
+  padding-left: 1.5rem;
+  margin: 0 0 1.4em;
+}
+
+.prose li {
+  margin-bottom: 0.4em;
+}
+
+.prose li > p {
+  margin: 0;
+}
+
+/* ─── Blockquote / pull quote ─────────────────────────────────────────────── */
+
+.prose blockquote {
+  margin: 2em 0;
+  padding: 1em 1.5em;
+  border-left: 3px solid rgba(22, 224, 245, 0.5);
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 0 8px 8px 0;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.prose blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+/* ─── Code ────────────────────────────────────────────────────────────────── */
+
+.prose code {
+  font-family: "SF Mono", "Fira Mono", "Cascadia Code", monospace;
+  font-size: 0.88em;
+  background: rgba(255, 255, 255, 0.07);
+  border-radius: 4px;
+  padding: 0.15em 0.4em;
+  color: rgba(22, 224, 245, 0.9);
+}
+
+.prose pre {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+  overflow-x: auto;
+  margin: 1.75em 0;
+}
+
+.prose pre code {
+  background: none;
+  padding: 0;
+  font-size: 0.92em;
+  color: rgba(255, 255, 255, 0.88);
+}
+
+/* ─── Horizontal rule ─────────────────────────────────────────────────────── */
+
+.prose hr {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  margin: 2.5em 0;
+}
+
+/* ─── Figures & captions ──────────────────────────────────────────────────── */
+
+.prose figure {
+  margin: 2em 0;
+}
+
+.prose figcaption {
+  margin-top: 0.6em;
+  font-size: 0.85rem;
+  text-align: center;
+  opacity: 0.65;
+}
+
+/* ─── Images ──────────────────────────────────────────────────────────────── */
+
+.prose img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+  display: block;
+}
+
+/* ─── Triptych layout ─────────────────────────────────────────────────────── */
+
+.triptych {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+  margin: 2em 0;
+}
+
+.triptych figure {
+  margin: 0;
+}
+
+.triptych img {
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  object-fit: cover;
+}
+
+@media (max-width: 640px) {
+  .triptych {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ─── Hero image ──────────────────────────────────────────────────────────── */
+
+.post-hero-image {
+  width: 100%;
+  max-height: 480px;
+  object-fit: cover;
+  border-radius: 12px;
+  margin-bottom: 2rem;
+  display: block;
+}
+
+/* ─── Post header ─────────────────────────────────────────────────────────── */
+
+.post-header {
+  margin-bottom: 2.5rem;
+}
+
+.post-header h1 {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  line-height: 1.2;
+  margin-bottom: 0.5rem;
+}
+
+.post-header .post-description {
+  font-size: 1.1rem;
+  opacity: 0.8;
+  max-width: 60ch;
+  line-height: 1.5;
+}

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "strictNullChecks": true,
+    "allowJs": true
+  }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Integrates `securepride-landing-bundle/site/` into `site/` as a complete Astro project ready for `astro build` and Cloudflare Pages deployment
- Completes all refinement tasks listed in the bundle README

## What's included

**Scaffold**
- `site/package.json` — Astro 4, `marked` 13
- `site/astro.config.mjs` — static output, `site: https://securepride.org`
- `site/tsconfig.json` — strict, strictNullChecks

**New: `BaseLayout.astro`** (was missing from bundle)
- Skip-to-content link, semantic `<header>`/`<footer>`, accessible nav
- Global `:focus-visible` ring (2px cyan outline) on all interactive elements
- CSS custom properties for the dark palette
- `md__rendered` prose utilities for landing page markdown sections
- `is:global` so tokens cascade into all child components

**Pages** — `/audit-toolkit`, `/get-started`, `/contact`, `/blog`, `/blog/[slug]`

**`<pre>` → safe build-time HTML** (refinement task 1)
- `Proof`, `ToolkitLayers`, `Deliverables`, `Trust`: replaced `<pre class="md__raw">` with `marked.parse(content, { breaks: true })` + Astro's `set:html`
- Runs server-side at build time; no client-side HTML injection possible
- `FAQ`: replaced `<pre>` with structured `<dl>/<dt>/<dd>` by parsing the custom `Q:/A:` format — semantically correct for FAQ content

**Heading hierarchy** (refinement task 2)
- Single `<h1>` per page: Hero on `/audit-toolkit`, explicit `<h1>` on `/get-started`, `/contact`, `/blog`, blog post titles
- All section headings are `<h2>`; FAQ is `<h3>` nested under Trust's `<h2>` ✓

**OG image** (refinement task 3)
- `site/public/og/securepride-audit-toolkit.png` copied from bundle ✓

**`/contact` wiring** (refinement task 4)
- Page retains the structured placeholder cards (guided review + security contact) with clear `<!-- Placeholder -->` hints; no dummy form submission wired

**`audit-toolkit.astro` head slot fix**
- Changed `<head>…</head>` passed to default slot → `<Fragment slot="head">` so canonical/OG tags land in `<head>`, not `<body>`; uses `Astro.site` for the canonical URL

## Test plan

- [ ] `cd site && npm install && npm run build` — confirm zero errors
- [ ] `npm run preview` — spot-check `/audit-toolkit`, `/get-started`, `/contact`, `/blog`
- [ ] Verify single `<h1>` per page in browser dev tools
- [ ] Tab through `/audit-toolkit` — confirm visible focus rings on all interactive elements
- [ ] Check OG tags with a meta inspector on `/audit-toolkit`
- [ ] Wire `/contact` form when the form endpoint is ready (placeholder clearly marked)

https://claude.ai/code/session_01EwaNREtjC5TCUSKXQgjGnb
EOF
)