### PR TITLE
fix(cf-pages): port contact handler, fix broken links, correct OG image

### DIFF
--- a/functions/api/contact.ts
+++ b/functions/api/contact.ts
@@ -1,0 +1,113 @@
+interface Env {
+  CONTACT_ENDPOINT?: string;
+  RESEND_API_KEY?: string;
+}
+
+interface ContactBody {
+  name?: unknown;
+  email?: unknown;
+  organization?: unknown;
+  message?: unknown;
+}
+
+export async function onRequestPost(context: {
+  request: Request;
+  env: Env;
+}): Promise<Response> {
+  const { request, env } = context;
+
+  const contentType = request.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    return Response.json({ error: 'Invalid content type.' }, { status: 400 });
+  }
+
+  let body: ContactBody;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: 'Invalid JSON.' }, { status: 400 });
+  }
+
+  const { name, email, organization, message } = body;
+
+  if (typeof name !== 'string' || typeof email !== 'string' || typeof message !== 'string') {
+    return Response.json({ error: 'Missing required fields.' }, { status: 400 });
+  }
+
+  if (!name.trim() || !email.trim() || !message.trim()) {
+    return Response.json({ error: 'Missing required fields.' }, { status: 400 });
+  }
+
+  if (name.length > 100 || email.length > 254 || message.length > 5000) {
+    return Response.json({ error: 'Input exceeds allowed length.' }, { status: 400 });
+  }
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return Response.json({ error: 'Invalid email address.' }, { status: 400 });
+  }
+
+  const org = typeof organization === 'string' ? organization.slice(0, 200) : '';
+
+  // Option 1: Forward to a custom endpoint
+  if (env.CONTACT_ENDPOINT) {
+    try {
+      const upstream = await fetch(env.CONTACT_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, organization: org, message }),
+      });
+      if (!upstream.ok) {
+        return Response.json({ error: 'Failed to send message. Please try again.' }, { status: 502 });
+      }
+    } catch {
+      return Response.json({ error: 'Failed to send message. Please try again.' }, { status: 502 });
+    }
+    return Response.json({ ok: true });
+  }
+
+  // Option 2: Send directly via Resend
+  if (env.RESEND_API_KEY) {
+    const subject = org
+      ? `Contact from ${name} (${org})`
+      : `Contact from ${name}`;
+
+    const text = [
+      `Name: ${name}`,
+      `Email: ${email}`,
+      org ? `Organization: ${org}` : null,
+      '',
+      message,
+    ].filter(Boolean).join('\n');
+
+    try {
+      const res = await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${env.RESEND_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: 'contact-form@securepride.org',
+          to: 'hello@securepride.org',
+          reply_to: email,
+          subject,
+          text,
+        }),
+      });
+
+      if (!res.ok) {
+        console.error('Resend error', res.status);
+        return Response.json({ error: 'Failed to send message. Please try again.' }, { status: 502 });
+      }
+    } catch (err) {
+      console.error('Resend error', err);
+      return Response.json({ error: 'Failed to send message. Please try again.' }, { status: 502 });
+    }
+
+    return Response.json({ ok: true });
+  }
+
+  // No delivery method configured — log and acknowledge so the form still works during setup
+  console.log('[contact-form]', { name, email, org, preview: message.slice(0, 80) });
+  return Response.json({ ok: true });
+}

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -26,17 +26,17 @@ import ContactForm from './ContactForm';
         </h3>
 
         <div class="space-y-6">
-          <!-- Documentation -->
+          <!-- Email -->
           <div>
-            <h4 class="mb-2 font-heading font-bold text-neon-cyan">Start with the Docs</h4>
+            <h4 class="mb-2 font-heading font-bold text-neon-cyan">Email us directly</h4>
             <p class="mb-3 text-text-secondary">
-              Our comprehensive documentation covers installation, configuration, and best practices.
+              Prefer email? We're reachable directly — no form required.
             </p>
             <a
-              href="https://docs.securepride.org"
+              href="mailto:hello@securepride.org"
               class="inline-flex items-center gap-2 text-neon-cyan transition-all duration-250 hover:text-neon-cyan hover:translate-x-1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neon-cyan"
             >
-              Read the Docs
+              hello@securepride.org
               <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
               </svg>
@@ -45,12 +45,14 @@ import ContactForm from './ContactForm';
 
           <!-- GitHub -->
           <div>
-            <h4 class="mb-2 font-heading font-bold text-neon-cyan">Check Out the Code</h4>
+            <h4 class="mb-2 font-heading font-bold text-neon-cyan">Open source</h4>
             <p class="mb-3 text-text-secondary">
               All our code is open-source. Contribute, fork, or learn from our repository.
             </p>
             <a
-              href="https://github.com/securepride"
+              href="https://github.com/mazze93/Secure-Pride"
+              target="_blank"
+              rel="noopener noreferrer"
               class="inline-flex items-center gap-2 text-neon-cyan transition-all duration-250 hover:text-neon-cyan hover:translate-x-1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neon-cyan"
             >
               View on GitHub

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -38,7 +38,7 @@
           <li><a href="#" class="text-[0.85rem] text-text-muted transition-colors duration-150 hover:text-brand-electric focus-visible:outline-neon-cyan">Dashboard</a></li>
           <li>
             <a
-              href="https://docs.securepride.org"
+              href="https://github.com/mazze93/Secure-Pride"
               target="_blank"
               rel="noopener noreferrer"
               class="text-[0.85rem] text-text-muted transition-colors duration-150 hover:text-brand-electric focus-visible:outline-neon-cyan"
@@ -58,7 +58,7 @@
         <ul class="flex flex-col gap-2 list-none" role="list">
           <li>
             <a
-              href="https://github.com/securepride"
+              href="https://github.com/mazze93/Secure-Pride"
               target="_blank"
               rel="noopener noreferrer"
               class="text-[0.85rem] text-text-muted transition-colors duration-150 hover:text-brand-electric focus-visible:outline-neon-cyan"
@@ -91,7 +91,7 @@
         <ul class="flex flex-col gap-2 list-none" role="list">
           <li>
             <a
-              href="https://docs.securepride.org"
+              href="https://github.com/mazze93/Secure-Pride"
               target="_blank"
               rel="noopener noreferrer"
               class="text-[0.85rem] text-text-muted transition-colors duration-150 hover:text-brand-electric focus-visible:outline-neon-cyan"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -43,12 +43,12 @@
       </li>
       <li>
         <a
-          href="https://docs.securepride.org"
+          href="https://github.com/mazze93/Secure-Pride"
           target="_blank"
           rel="noopener noreferrer"
           class="font-heading text-[0.95rem] font-semibold uppercase tracking-[0.05em] text-text-secondary transition-colors duration-250 hover:text-brand-electric focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-electric rounded-sm"
         >
-          Docs
+          GitHub
         </a>
       </li>
       <li>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,7 +13,7 @@ const {
   title,
   description = 'SecurePride helps organizations detect and protect against AI-powered prompt injection and data exposure. Deploy in minutes. Understand threats in plain language.',
   canonicalUrl,
-  ogImage = 'https://securepride.org/og-image.png',
+  ogImage = 'https://securepride.org/sp-og-preview.png',
   noindex = false,
 } = Astro.props;
 


### PR DESCRIPTION
## Summary

- **Contact form now works on Cloudflare Pages** — ported from dead Vercel handler to CF Pages Function
- **All broken external links fixed** — `github.com/securepride` and `docs.securepride.org` replaced throughout
- **OG image corrected** — default was pointing to `og-image.png` (missing); now uses `sp-og-preview.png`

## Changes

**`functions/api/contact.ts`** (new — replaces `api/contact.ts`)
- Cloudflare Pages Function format (`onRequestPost`) instead of `@vercel/node`
- Delivery chain: `CONTACT_ENDPOINT` env var → `RESEND_API_KEY` (sends to `hello@securepride.org`) → log-only fallback during setup
- Input validation: type checks, length limits, email format

**`src/components/Contact.astro`**
- Removed dead "Start with the Docs" link (`docs.securepride.org`)
- Added `mailto:hello@securepride.org` as a visible direct-email option
- GitHub link corrected to `mazze93/Secure-Pride`

**`src/components/Footer.astro`**
- All `docs.securepride.org` → `github.com/mazze93/Secure-Pride`
- All `github.com/securepride` → `github.com/mazze93/Secure-Pride`

**`src/components/Header.astro`**
- "Docs" nav item → "GitHub" pointing to `mazze93/Secure-Pride`

**`src/layouts/Layout.astro`**
- Default OG image: `og-image.png` → `sp-og-preview.png`

## To go fully live after merging

1. **Cloudflare Pages dashboard** — confirm build settings:
   - Build command: `npm run build`
   - Output directory: `dist`
   - Node version: 22
2. **CF Pages env vars** — add `RESEND_API_KEY` to enable contact form delivery (Resend free tier works; domain `securepride.org` must be verified in Resend)
3. **`/privacy` and `/security` pages** — contain "this is a template" warnings; need real policy content before public launch

## Test plan
- [ ] Submit contact form → check CF Pages Function logs for `[contact-form]` entry (before Resend is wired)
- [ ] Add `RESEND_API_KEY` env var → submit form → confirm delivery to `hello@securepride.org`
- [ ] Verify OG image renders on `/` via a meta inspector
- [ ] Check all nav/footer links resolve

https://claude.ai/code/session_01EwaNREtjC5TCUSKXQgjGnb

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwaNREtjC5TCUSKXQgjGnb)_